### PR TITLE
Add angle offsets to calibrate new assembly + Update holding stiffness

### DIFF
--- a/mcu/.settings/language.settings.xml
+++ b/mcu/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-86217308919109461" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-1391605500807072415" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-86217308919109461" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" console="false" env-hash="-1391605500807072415" id="fr.ac6.mcu.ide.build.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="Ac6 SW4 STM32 MCU Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mcu/Inc/LSS/lss.h
+++ b/mcu/Inc/LSS/lss.h
@@ -34,6 +34,7 @@ typedef struct
 {
     uint8_t id;                 /**< Motor identification */
     UART_HandleTypeDef* p_uart; /**< UART handle for motor */
+    float offset; /**< Additive offset for calibration on assembly. + is cw */
 }lss_t;
 
 /** @brief Enumerates the low-level I/O modes the library supports */

--- a/mcu/Src/LSS/lss.c
+++ b/mcu/Src/LSS/lss.c
@@ -115,6 +115,7 @@ void lss_reset(lss_t* hlss)
 void lss_set_position(lss_t* hlss, float angle)
 {
     uint8_t buff[16];
+    angle += hlss->offset;
     uint8_t length = snprintf((char*)buff, 16, "#%dD%d", hlss->id, (int)(10.0 * angle));
     buff[length] = '\r'; // Overwrite null character with cmd termination
     lss_transmit(hlss, buff, length + 1);
@@ -125,6 +126,7 @@ void lss_set_position(lss_t* hlss, float angle)
 void lss_set_position_timed(lss_t* hlss, float angle, uint16_t time_ms)
 {
     uint8_t buff[16];
+    angle += hlss->offset;
     uint8_t length = snprintf((char*)buff, 16, "#%dD%dT%d", hlss->id, (int)(10.0 * angle), time_ms);
     buff[length] = '\r'; // Overwrite null character with cmd termination
     lss_transmit(hlss, buff, length + 1);
@@ -174,7 +176,7 @@ void lss_set_led(lss_t* hlss, lss_colors_t color)
         return;
     }
     uint8_t buff[16];
-    uint8_t length = snprintf((char*)buff, 16, "#%dLED%d", hlss->id, color);
+    uint8_t length = snprintf((char*)buff, 16, "#%dCLED%d", hlss->id, color);
     buff[length] = '\r'; // Overwrite null character with cmd termination
     lss_transmit(hlss, buff, length + 1);
 }

--- a/mcu/Src/freertos.c
+++ b/mcu/Src/freertos.c
@@ -526,24 +526,28 @@ void StartControlTask(void const * argument)
     lss_set_io_type(IO_DMA);
 
     const int8_t ANGULAR_STIFFNESS = -4;
-    const int8_t HOLDING_STIFFNESS = 0;
+    const int8_t HOLDING_STIFFNESS = -4;
     const uint8_t OUTER_ID = 1;
-    lss_t servo_outer = {OUTER_ID, &huart1};
+    const float OUTER_OFFSET = 49;
+    const uint16_t AA = 1000;
+    const uint16_t AD = 1000;
+    lss_t servo_outer = {OUTER_ID, &huart1, OUTER_OFFSET};
     lss_set_led(&servo_outer, LSS_OFF);
     lss_toggle_motion_ctrl(&servo_outer, LSS_EM0);
     lss_set_speed(&servo_outer, 180.0);
-    lss_set_aa(&servo_outer, 1000);
-    lss_set_ad(&servo_outer, 1000);
+    lss_set_aa(&servo_outer, AA);
+    lss_set_ad(&servo_outer, AD);
     lss_set_as(&servo_outer, ANGULAR_STIFFNESS);
     lss_set_hs(&servo_outer, HOLDING_STIFFNESS);
 
     const uint8_t INNER_ID = 0;
-    lss_t servo_inner = {INNER_ID, &huart1};
+    const float INNER_OFFSET = -102;
+    lss_t servo_inner = {INNER_ID, &huart1, INNER_OFFSET};
     lss_set_led(&servo_inner, LSS_OFF);
     lss_toggle_motion_ctrl(&servo_inner, LSS_EM0);
     lss_set_speed(&servo_inner, 180.0);
-    lss_set_aa(&servo_inner, 1000);
-    lss_set_ad(&servo_inner, 1000);
+    lss_set_aa(&servo_inner, AA);
+    lss_set_ad(&servo_inner, AD);
     lss_set_as(&servo_inner, ANGULAR_STIFFNESS);
     lss_set_hs(&servo_inner, HOLDING_STIFFNESS);
 


### PR DESCRIPTION
In future it would be nice if these were stored in the data table and reprogrammable via Python

Holding stiffness = -4 seems to produce smoother motion for small angles (a bit less jitter)