### PR TITLE
Swap motor IDs on embedded side + add workaround for Mac OS update_origin command

### DIFF
--- a/mcu/Src/freertos.c
+++ b/mcu/Src/freertos.c
@@ -566,8 +566,8 @@ void StartControlTask(void const * argument)
 
     const int8_t ANGULAR_STIFFNESS = -4;
     const int8_t HOLDING_STIFFNESS = -4;
-    const uint8_t OUTER_ID = 1;
-    const float OUTER_OFFSET = 49;
+    const uint8_t OUTER_ID = 0;
+    const float OUTER_OFFSET = -102;
     const uint16_t AA = 1000;
     const uint16_t AD = 1000;
     lss_t servo_outer = {OUTER_ID, &huart1, OUTER_OFFSET};
@@ -579,8 +579,8 @@ void StartControlTask(void const * argument)
     lss_set_as(&servo_outer, ANGULAR_STIFFNESS);
     lss_set_hs(&servo_outer, HOLDING_STIFFNESS);
 
-    const uint8_t INNER_ID = 0;
-    const float INNER_OFFSET = -102;
+    const uint8_t INNER_ID = 1;
+    const float INNER_OFFSET = 49;
     lss_t servo_inner = {INNER_ID, &huart1, INNER_OFFSET};
     lss_set_led(&servo_inner, LSS_OFF);
     lss_toggle_motion_ctrl(&servo_inner, LSS_EM0);

--- a/pc/tx.py
+++ b/pc/tx.py
@@ -131,6 +131,7 @@ def send_reference_point_update(port, baud, angles):
     
     try:
         with serial.Serial(port, baud, timeout=0) as ser:
+            enable_servos(ser)
             cmd_id = CMD_ZERO_REF.encode()
             payload = struct.pack('<f', a_outer) + struct.pack('<f', a_inner)
             packet = cmd_id + payload

--- a/pc/util.py
+++ b/pc/util.py
@@ -213,7 +213,7 @@ def parse_args():
              ' on. Example: --update_origin=0,0 will remove any origin '
              ' translation previously applied. Example: --update_origin=10,-10'
              ' will cause the servo on the outer gimbal to treat a +10 degree'
-             ' deflection as 0 degrees, and the sero on the inner gimbal to'
+             ' deflection as 0 degrees, and the servo on the inner gimbal to'
              ' treat a -10 degree deflection as 0 degrees. NOTE: this setting'
              ' does NOT persist between power cycles, and is 0 by default',
         default=''


### PR DESCRIPTION
- Physical servo locations were inconsistent with their logical locations in software; swapped them and their calibration

- update_origin was misbehaving on Mac OS (behaviour inconsistent with Windows). While trying to find the root cause, I discovered a workaround which is simply calling `enable_servos(ser)` before sending the origin-updating command. Some observations for the record:
  - Packet contents were _identical_ on the two platforms, so I think the inconsistency must be at the level of the serial port library
  - `update_origin` works perfectly fine on Windows. Some of the inconsistent behaviours on Mac OS are: (1) sending `update_origin=0,0` twice in a row results in a deflection of the inner gimbal, while sending it once does not (the `update_origin` command should be idempotent for identical arguments!), (2) after sending `update_origin=0,0` twice, the inner gimbal becomes unresponsive to all commands