### PR TITLE
MCU code updates

### DIFF
--- a/mcu/Inc/LSS/lss.h
+++ b/mcu/Inc/LSS/lss.h
@@ -92,6 +92,12 @@ enum IO_FLAGS lss_get_io_type();
 void lss_reset(lss_t* hlss);
 
 /**
+ * @brief Kills power to servo, causing it to go limp
+ * @param hlss Handle for the motor
+ */
+void lss_goLimp(lss_t* hlss);
+
+/**
  * @brief Sends command to move the servo to the specified angle
  * @param hlss Handle for the motor in degrees
  * @param angle Desired angle for motor

--- a/mcu/Src/LSS/lss.c
+++ b/mcu/Src/LSS/lss.c
@@ -112,6 +112,16 @@ void lss_reset(lss_t* hlss)
 
 //-----------------------------------------------------------------------------
 
+void lss_goLimp(lss_t* hlss)
+{
+    uint8_t buff[16];
+    uint8_t length = snprintf((char*)buff, 16, "#%dL", hlss->id);
+    buff[length] = '\r'; // Overwrite null character with cmd termination
+    lss_transmit(hlss, buff, length + 1);
+}
+
+//-----------------------------------------------------------------------------
+
 void lss_set_position(lss_t* hlss, float angle)
 {
     uint8_t buff[16];

--- a/mcu/Src/freertos.c
+++ b/mcu/Src/freertos.c
@@ -313,6 +313,7 @@ void StartRxTask(void const * argument)
         CMD_ZERO_REF = 'Z',
         CMD_ZERO_REF_OUTER = 'O',
         CMD_ZERO_REF_INNER = 'I',
+        CMD_RESET = 'R',
         CMD_ANGLE = 'A',
         CMD_ANGLE_OUTER = '8', // Exact value doesn't matter, just has to be
         CMD_ANGLE_INNER = '9'  // unique (these are used as parse states only)
@@ -334,6 +335,10 @@ void StartRxTask(void const * argument)
                     if ((char)data == (char)CMD_BLINK)
                     {
                         parse_state = CMD_BLINK;
+                    }
+                    else if ((char)data == (char)CMD_RESET)
+                    {
+                        parse_state = CMD_RESET;
                     }
                     else if ((char)data == (char)CMD_ANGLE)
                     {
@@ -372,6 +377,11 @@ void StartRxTask(void const * argument)
                 case CMD_BLINK:
                     blink_camera_led();
                     parse_state = CMD_NONE;
+                    break;
+                case CMD_RESET:
+                    taskENTER_CRITICAL();
+
+                    NVIC_SystemReset();
                     break;
                 case CMD_ANGLE:
                     parse_state = CMD_ANGLE_OUTER;

--- a/mcu/Src/freertos.c
+++ b/mcu/Src/freertos.c
@@ -320,7 +320,8 @@ void StartRxTask(void const * argument)
     } parse_state = CMD_NONE;
 
     MX_WWDG_Init();
-    disable_control();
+//    disable_control();
+    enable_control();
     HAL_UART_Receive_DMA(&huart2, rx_buff, sizeof(rx_buff));
     for(;;)
     {
@@ -448,7 +449,7 @@ void StartRxTask(void const * argument)
                     break;
             }
         }
-        if (huart2.RxState == HAL_UART_STATE_ERROR)
+        if (huart2.RxState == HAL_UART_STATE_ERROR || huart2.ErrorCode != HAL_UART_ERROR_NONE)
         {
             HAL_UART_AbortReceive(&huart2);
             HAL_UART_Receive_DMA(&huart2, rx_buff, sizeof(rx_buff));

--- a/mcu/Src/freertos.c
+++ b/mcu/Src/freertos.c
@@ -380,7 +380,6 @@ void StartRxTask(void const * argument)
                     break;
                 case CMD_RESET:
                     taskENTER_CRITICAL();
-
                     NVIC_SystemReset();
                     break;
                 case CMD_ANGLE:

--- a/pc/filters.py
+++ b/pc/filters.py
@@ -3,8 +3,11 @@
 # Date: January 11, 2019
 
 import numpy as np
-from scipy.signal import butter, lfilter, freqz
-from util import Z_IDX, Y_IDX, X_IDX
+from util import Z_IDX, Y_IDX, X_IDX, logString
+try:
+    from scipy.signal import butter, lfilter, freqz
+except:
+    logString("Could not import scipy.signal")
 
 class cFilt:
     ''' Complementary filter '''

--- a/pc/rx.py
+++ b/pc/rx.py
@@ -8,8 +8,11 @@ import serial
 import os
 import struct
 import numpy as np
-from prettytable import PrettyTable
 from util import *
+try:
+    from prettytable import PrettyTable
+except:
+    logString("Failed to import PrettyTable")
     
 def print_imu(data):
     '''

--- a/pc/tx.py
+++ b/pc/tx.py
@@ -15,7 +15,7 @@ def transmit_angles(ser, a_outer, a_inner, dryrun=False):
     Sends angle data to the MCU
     --------
     Arguments:
-        port : serial.Serial
+        ser : serial.Serial
             COM port that MCU is connected to
         a_outer : float
             Outer gimbal angle
@@ -27,7 +27,7 @@ def transmit_angles(ser, a_outer, a_inner, dryrun=False):
     if dryrun:
         logString("Outer: {0}|Inner: {1}".format(a_outer, a_inner))
     else:
-        cmd_id = CMD_ANGLE.encode() # A => Angle payload
+        cmd_id = CMD_ANGLE.encode() # Angle payload
         # It turns out that rounding error for ints is noticable, especially at
         # low playback frequencies (e.g. 10*sin(2*pi*0.1*t)) and for small angles. So
         # we're sticking with floats
@@ -35,6 +35,15 @@ def transmit_angles(ser, a_outer, a_inner, dryrun=False):
         packet = cmd_id + payload
         ser.write(packet)
     return
+
+def transmit_mcu_reset(ser):
+    '''
+    Sends a command to the MCU which causes it to perform a hard reset
+    --------
+    Arguments:
+        port : serial.Serial
+    '''
+    ser.write(CMD_RESET.encode())
 
 def send_servo_angles(port, baud, angles):
     '''

--- a/pc/util.py
+++ b/pc/util.py
@@ -335,8 +335,9 @@ CMD_CTRL_DI = '0'
 CMD_CTRL_EN = '1'
 CMD_SENS_DI = '2'
 CMD_SENS_EN = '3'
-CMD_ANGLE = 'A'
 CMD_ZERO_REF = 'Z'
+CMD_RESET = 'R'
+CMD_ANGLE = 'A'
 def enable_servos(ser):
     '''
     Sends the MCU a command to enable servo actuation


### PR DESCRIPTION
Fixes #53.

Seems like the root cause was a UART framing error caused by the RPi transmitting some junk data to the MCU right before its first transmission. I thought the MCU code would have been robust to such issues, since I was conditionally resetting the USART hardware if `huart2.RxState` indicated an error. However, it turns out I actually had to check `huart2.ErrorCode` to catch framing errors.

Upon making this fix to the MCU code, playback successfully started up autonomously on the RPi several times, as desired!

This PR also brings in a reset command for the MCU which can be issued from within the Python code. Also implements `lss_goLimp` on the MCU side because I thought it might be useful to have sitting around.